### PR TITLE
Change version of parent pom and use different dependency for functional-utils library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-starter-parent</artifactId>
-        <version>Brixton.M4</version>
+        <version>Brixton.RELEASE</version>
         <!-- lookup parent from repository -->
     </parent>
 
@@ -47,9 +47,9 @@
             <version>4.5.1</version>
         </dependency>
         <dependency>
-            <groupId>se.aftonbladet</groupId>
+            <groupId>fi.solita.utils</groupId>
             <artifactId>functional-utils</artifactId>
-            <version>0.0.11</version>
+            <version>0.9.22</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/jebl01/ArtifactoryRepository.java
+++ b/src/main/java/jebl01/ArtifactoryRepository.java
@@ -8,14 +8,14 @@ import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import se.aftonbladet.utils.functional.Either;
+import fi.solita.utils.functional.Either;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URI;
 
-import static se.aftonbladet.utils.functional.Either.left;
-import static se.aftonbladet.utils.functional.Either.right;
+import static fi.solita.utils.functional.Either.left;
+import static fi.solita.utils.functional.Either.right;
 
 /**
  * Created by jesblo on 15-12-22.

--- a/src/main/java/jebl01/ArtifactsEndpoint.java
+++ b/src/main/java/jebl01/ArtifactsEndpoint.java
@@ -2,7 +2,7 @@ package jebl01;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import se.aftonbladet.utils.functional.Either;
+import fi.solita.utils.functional.Either;
 
 import javax.imageio.ImageIO;
 import javax.ws.rs.GET;
@@ -37,7 +37,7 @@ public class ArtifactsEndpoint {
         return output -> ImageIO.write(
             BadgeGenerator.generate(
                 "artifactory",
-                result.getRight().orElseGet(() -> result.getLeft().get()),
+                Either.get(result),
                 result.isRight()),
             "png",
             output);


### PR DESCRIPTION
Use Brixton.RELEASE as parent pom version available on maven-central/jcenter and refactor to use new dependency for functional-utils library instead that is released on Github.